### PR TITLE
Add extra check for PE file

### DIFF
--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -177,7 +177,7 @@ event file_state_remove(f: fa_file)
     {
 	# If any of the detailed logging is enabled, delete the default section_names field.
 	# This means that default functionality is not changed.
-	if ( pe_log_section_flags  || pe_log_section_entropy )
+	if ( ( pe_log_section_flags || pe_log_section_entropy ) && f?$pe )
 		{
 		f$pe$section_names = vector();
 		for ( section, info in f$pe$section_info_table )

--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -175,9 +175,14 @@ event pe_import_table(f: fa_file, it: PE::ImportTable) {
 # Called when the file analysis is closed.
 event file_state_remove(f: fa_file)
     {
+	if ( ! f?$pe )
+		{
+		return;
+		}
+
 	# If any of the detailed logging is enabled, delete the default section_names field.
 	# This means that default functionality is not changed.
-	if ( ( pe_log_section_flags || pe_log_section_entropy ) && f?$pe )
+	if ( pe_log_section_flags || pe_log_section_entropy )
 		{
 		f$pe$section_names = vector();
 		for ( section, info in f$pe$section_info_table )


### PR DESCRIPTION
The `file_state_remove` event override didn't check for the presence of a PE file in file `f`. An extra check is added to remove the annoying  `expression error in /opt/zeek/share/zeek/site/packages/spicy-pe/main.zeek, line 182: field value missing (PE::f$pe)` error.