### PR TITLE
Make test pass with both old-style and new-style Spicy error output.

### DIFF
--- a/tests/analyzer/infinite-loop.spicy
+++ b/tests/analyzer/infinite-loop.spicy
@@ -1,4 +1,5 @@
 # @TEST-DOC: This test validates that inputs containing infinite pointer loops are rejected.
 #
-# @TEST-EXEC-FAIL: spicy-driver -d ${DIST}/analyzer/analyzer.spicy -f ${TRACES}/infinite-loop.dat >output 2>&1
+# @TEST-EXEC-FAIL: spicy-driver -d ${DIST}/analyzer/analyzer.spicy -f ${TRACES}/infinite-loop.dat >output.tmp 2>&1
+# @TEST-EXEC: cat output.tmp | sed -E 's/-[0-9]*:[0-9]*//' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Newer versions of Spicy include column information into the location.
